### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest
+pytest-asyncio

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,42 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    "Basketball Team": {
+        "description": "Team practices, skill drills, and inter-school basketball games",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Soccer Club": {
+        "description": "Soccer training sessions and friendly matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["ava@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Art Workshop": {
+        "description": "Explore painting, sketching, and mixed-media art projects",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["mia@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting practice, script reading, and stage performances",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Debate Society": {
+        "description": "Develop public speaking and critical argumentation skills",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["elijah@mergington.edu", "james@mergington.edu"]
+    },
+    "Science Olympiad": {
+        "description": "Hands-on science challenges and competition preparation",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["lucas@mergington.edu", "henry@mergington.edu"]
+    },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantItems = details.participants.length
+          ? details.participants.map(p => `<li>${p}<button class="unregister-btn" data-activity="${name}" data-email="${p}" title="Unregister">&times;</button></li>`).join("")
+          : "<li class='no-participants'>No participants yet</li>";
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title">Signed Up</p>
+            <ul class="participants-list">${participantItems}</ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -40,6 +48,34 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error fetching activities:", error);
     }
   }
+
+  // Handle unregister button clicks
+  activitiesList.addEventListener("click", async (event) => {
+    if (!event.target.classList.contains("unregister-btn")) return;
+
+    const btn = event.target;
+    const activity = btn.dataset.activity;
+    const email = btn.dataset.email;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+
+      if (response.ok) {
+        await fetchActivities();
+      } else {
+        const result = await response.json();
+        messageDiv.textContent = result.detail || "Failed to unregister";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+        setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+      }
+    } catch (error) {
+      console.error("Error unregistering:", error);
+    }
+  });
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
@@ -62,6 +98,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,65 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants-title {
+  font-weight: bold;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #555;
+  margin-bottom: 6px;
+}
+
+.participants-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.participants-list li {
+  background-color: #e8eaf6;
+  color: #1a237e;
+  font-size: 0.8rem;
+  padding: 3px 10px;
+  border-radius: 12px;
+  border: 1px solid #c5cae9;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.unregister-btn {
+  background: none;
+  border: none;
+  color: #7986cb;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.unregister-btn:hover {
+  background-color: transparent;
+  color: #c62828;
+}
+
+.participants-list li.no-participants {
+  background-color: #f5f5f5;
+  color: #999;
+  border-color: #ddd;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,157 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+from src.app import app
+
+INITIAL_ACTIVITIES = {
+    name: {**data, "participants": list(data["participants"])}
+    for name, data in app_module.activities.items()
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Restore the in-memory activities dict to its original state after each test."""
+    app_module.activities.clear()
+    app_module.activities.update(
+        {name: {**data, "participants": list(data["participants"])}
+         for name, data in INITIAL_ACTIVITIES.items()}
+    )
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# ── GET /activities ───────────────────────────────────────────────────────────
+
+def test_get_activities_returns_all(client):
+    # Arrange — default activities are loaded via fixture
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 9
+    assert "Basketball Team" in data
+    assert "Soccer Club" in data
+
+
+def test_get_activities_has_expected_fields(client):
+    # Arrange — nothing extra needed
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    activity = response.json()["Chess Club"]
+    assert "description" in activity
+    assert "schedule" in activity
+    assert "max_participants" in activity
+    assert "participants" in activity
+
+
+# ── POST /activities/{activity_name}/signup ───────────────────────────────────
+
+def test_signup_success(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "newstudent@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert email in response.json()["message"]
+    assert email in app_module.activities[activity_name]["participants"]
+
+
+def test_signup_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "a@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_duplicate(client):
+    # Arrange — michael is already a participant in Chess Club
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up"
+
+
+# ── DELETE /activities/{activity_name}/signup ─────────────────────────────────
+
+def test_unregister_success(client):
+    # Arrange — michael is already a participant in Chess Club
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert email not in app_module.activities[activity_name]["participants"]
+
+
+def test_unregister_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "a@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_not_signed_up(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "notregistered@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student is not signed up for this activity"


### PR DESCRIPTION
This pull request adds support for unregistering students from activities, expands the activity database, enhances the frontend to display participants and allow unregistering, and introduces comprehensive backend tests. The main changes are grouped below by theme:

**Backend API enhancements:**

* Added six new activities to the `activities` database in `src/app.py`, each with descriptions, schedules, participant limits, and initial participants.
* Introduced a new DELETE endpoint (`/activities/{activity_name}/signup`) in `src/app.py` to allow students to unregister from activities, including error handling for unknown activities and students not registered.
* Updated signup logic to prevent duplicate registrations by checking if a student is already signed up.

**Frontend improvements:**

* Enhanced the activity cards in `src/static/app.js` to display a list of participants for each activity, including an "Unregister" button for each participant.
* Implemented frontend logic in `src/static/app.js` to handle unregister button clicks, sending DELETE requests to the backend and updating the UI accordingly.
* Refreshed the activity list after a successful signup to reflect changes immediately.

**Styling updates:**

* Added new CSS classes in `src/static/styles.css` for participant lists, titles, and unregister buttons, improving the visual presentation and usability of participant management.

**Testing:**

* Added a new test suite in `tests/test_app.py` covering activity listing, signup, duplicate signup prevention, unregistering, error cases, and state restoration between tests.